### PR TITLE
Updated resume url

### DIFF
--- a/web/app.html
+++ b/web/app.html
@@ -220,7 +220,7 @@
 			</section>
 			<section>
 				<h3>Resumé</h3>
-				<p><a class="external" href="https://chesleybrown.github.io/resume/chesleybrown.html">HTML</a> or <a class="external" href="https://chesleybrown.github.io/resume/chesleybrown.pdf">PDF</a></p>
+				<p><a class="external" href="https://chesleybrown.github.io/resume">HTML</a> or <a class="external" href="https://chesleybrown.github.io/resume/chesleybrown.pdf">PDF</a></p>
 			</section>
 			<div class="fade"></div>
 		</div>


### PR DESCRIPTION
The html version of the resume has been renamed to `index.html`. This means we do not need to provide the file name anymore as it will serve that by default.

To confirm this works, visit: https://chesleybrown.github.io/resume/